### PR TITLE
Fix: Center footer copyright text

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About BYAMN - YouTube Learning Verified Achievement Platform</title>
-    <meta name="description" content="Discover BYAMN's mission to transform YouTube learning into verified achievement. Free certificates, progress tracking, and 200+ expert-led courses for career advancement."
+    <meta name="description" content="Discover BYAMN's mission to transform YouTube learning into verified achievement. Free certificates, progress tracking, and 200+ expert-led courses for career advancement.">
     <link rel="icon" type="image/png" href="./logo.png">
     
     <!-- Tailwind CSS CDN -->
@@ -211,9 +211,9 @@
                 </div>
             </div>
             
-            <div class="border-t border-neutral-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
-                <p class="text-neutral-300">© 2025 BYAMN. All rights reserved.</p>
-                <div class="flex space-x-6 mt-4 md:mt-0">
+            <div class="border-t border-neutral-800 mt-12 pt-8 flex flex-col items-center text-center">
+                <p class="text-neutral-300 mb-4">© 2025 BYAMN. All rights reserved.</p>
+                <div class="flex space-x-6">
                     <a href="#" class="text-neutral-300 hover:text-white transition-colors">
                         <span class="sr-only">Facebook</span>
                         <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">


### PR DESCRIPTION
## Description
Fixes #19 - Center footer copyright text (© 2025 BYAMN. All rights reserved.)

## Changes Made
- Changed footer layout from `justify-between` to centered alignment
- Copyright text now displays in center instead of left-aligned  
- Social media icons remain below copyright text, also centered
- Applied fix to about.html (can be extended to other pages if needed)

## Technical Details
**Before:**
```html
<div class="... flex flex-col md:flex-row justify-between items-center">
    <p class="text-neutral-300">© 2025 BYAMN. All rights reserved.</p>
    <div class="flex space-x-6 mt-4 md:mt-0">
        <!-- Social icons -->
    </div>
</div>
```

**After:**
```html
<div class="... flex flex-col items-center text-center">
    <p class="text-neutral-300 mb-4">© 2025 BYAMN. All rights reserved.</p>
    <div class="flex space-x-6">
        <!-- Social icons -->
    </div>
</div>
```

## Visual Changes
- Copyright text is now centered on all screen sizes
- Social icons appear below the copyright text, also centered
- Removed responsive flex-row layout in favor of consistent vertical stacking
- Added margin-bottom to copyright for better spacing

## Testing
- ✅ Copyright text centered on desktop
- ✅ Copyright text centered on mobile
- ✅ Social icons properly aligned below copyright
- ✅ No layout breaks or styling issues

## Screenshots
The footer copyright and social icons are now properly centered as requested in the issue.