### PR TITLE
Add Contributors Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ We welcome contributions to improve the BYAMN Learning Platform. To contribute:
 4. Push to the branch (`git push origin feature/AmazingFeature`)
 5. Open a Pull Request
 
+
+## ✨ Contributors
+
+#### Thanks to all the wonderful contributors 💖
+
+<a href="https://github.com/DYHARDx/BYAMN-Learning/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=DYHARDx/BYAMN-Learning" />
+</a>
+
+#### See full list of contributor contribution [Contribution Graph](https://github.com/DYHARDx/BYAMN-Learning/graphs/contributors)  
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Description
This PR adds a Contributors section to the README.md to recognize and showcase all contributors, making the repository more welcoming for new contributors.

Current Problem
The README.md currently lacks a Contributors section to recognize contributors and guide new ones.

Proposed Solution
Add a Contributors section at the end of README.md
Include an auto-generated contributor badge via [contrib.rocks](https://contrib.rocks/)
Update Table of Contents to include this new section
Keep all existing content intact and improve formatting where necessary

Benefits
Recognizes contributors and shows appreciation
Makes the repository more welcoming for new contributors
Improves documentation readability and structure

Close #18
