### PR TITLE
Center footer copyright text

### DIFF
--- a/about.html
+++ b/about.html
@@ -223,9 +223,9 @@
                 </div>
             </div>
             
-            <div class="border-t border-neutral-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
-                <p class="text-neutral-300">© 2025 BYAMN. All rights reserved.</p>
-                <div class="flex space-x-6 mt-4 md:mt-0">
+            <div class="border-t border-neutral-800 mt-12 pt-8 flex flex-col items-center text-center">
+                <p class="text-neutral-300 mb-4">© 2025 BYAMN. All rights reserved.</p>
+                <div class="flex space-x-6">
                     <a href="#" class="text-neutral-300 hover:text-white transition-colors">
                         <span class="sr-only">Facebook</span>
                         <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">


### PR DESCRIPTION
## Description
Close #19 - Center footer copyright text (© 2025 BYAMN. All rights reserved.)

## Changes Made
Changed footer layout from justify-between to centered alignment
Copyright text now displays in center instead of left-aligned
Social media icons remain below copyright text, also centered
Applied fix to about.html (can be extended to other pages if needed)