### PR TITLE
Fix: replace legacy Twitter icon with X logo globally

### DIFF
--- a/about.html
+++ b/about.html
@@ -315,21 +315,18 @@
               </svg>
             </a>
             <a
-              href="#"
-              class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"
-            >
-              <span class="sr-only">Twitter</span>
-              <svg
-                class="h-6 w-6"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84"
-                ></path>
-              </svg>
-            </a>
+      href="#"
+      class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"
+    >
+      <span class="sr-only">X (Twitter)</span> <svg
+        class="h-6 w-6"
+        fill="currentColor"
+        viewBox="0 0 512 512"
+        aria-hidden="true"
+      >
+        <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/>
+      </svg>
+    </a>
             <a
               href="#"
               class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"

--- a/certificate.html
+++ b/certificate.html
@@ -420,12 +420,19 @@
                             <path fill-rule="evenodd" d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z" clip-rule="evenodd"></path>
                         </svg>
                     </a>
-                    <a href="#" class="text-neutral-300 hover:text-white transition-colors">
-                        <span class="sr-only">Twitter</span>
-                        <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84"></path>
-                        </svg>
-                    </a>
+                    <a
+  href="#"
+  class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"
+>
+  <span class="sr-only">X (Twitter)</span> <svg
+    class="h-6 w-6"
+    fill="currentColor"
+    viewBox="0 0 512 512"
+    aria-hidden="true"
+  >
+    <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/>
+  </svg>
+</a>
                     <a href="#" class="text-neutral-300 hover:text-white transition-colors">
                         <span class="sr-only">LinkedIn</span>
                         <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">

--- a/contact.html
+++ b/contact.html
@@ -334,15 +334,19 @@
                 clip-rule="evenodd"></path>
             </svg>
           </a>
-          <a href="#"
-            class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110">
-            <span class="sr-only">Twitter</span>
-            <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path
-                d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84">
-              </path>
-            </svg>
-          </a>
+          <a
+  href="#"
+  class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"
+>
+  <span class="sr-only">X (Twitter)</span> <svg
+    class="h-6 w-6"
+    fill="currentColor"
+    viewBox="0 0 512 512"
+    aria-hidden="true"
+  >
+    <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/>
+  </svg>
+</a>
           <a href="#"
             class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110">
             <span class="sr-only">LinkedIn</span>

--- a/courses.html
+++ b/courses.html
@@ -703,21 +703,18 @@
               </svg>
             </a>
             <a
-              href="#"
-              class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"
-            >
-              <span class="sr-only">Twitter</span>
-              <svg
-                class="h-6 w-6"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84"
-                ></path>
-              </svg>
-            </a>
+  href="#"
+  class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"
+>
+  <span class="sr-only">X (Twitter)</span> <svg
+    class="h-6 w-6"
+    fill="currentColor"
+    viewBox="0 0 512 512"
+    aria-hidden="true"
+  >
+    <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/>
+  </svg>
+</a>
             <a
               href="#"
               class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"

--- a/dashboard.html
+++ b/dashboard.html
@@ -477,12 +477,19 @@
                             <path fill-rule="evenodd" d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z" clip-rule="evenodd"></path>
                         </svg>
                     </a>
-                    <a href="#" class="text-neutral-300 hover:text-white transition-colors">
-                        <span class="sr-only">Twitter</span>
-                        <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84"></path>
-                        </svg>
-                    </a>
+                    <a
+  href="#"
+  class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"
+>
+  <span class="sr-only">X (Twitter)</span> <svg
+    class="h-6 w-6"
+    fill="currentColor"
+    viewBox="0 0 512 512"
+    aria-hidden="true"
+  >
+    <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/>
+  </svg>
+</a>
                     <a href="#" class="text-neutral-300 hover:text-white transition-colors">
                         <span class="sr-only">LinkedIn</span>
                         <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">

--- a/faq.html
+++ b/faq.html
@@ -351,21 +351,18 @@
               </svg>
             </a>
             <a
-              href="#"
-              class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"
-            >
-              <span class="sr-only">Twitter</span>
-              <svg
-                class="h-6 w-6"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84"
-                ></path>
-              </svg>
-            </a>
+  href="#"
+  class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"
+>
+  <span class="sr-only">X (Twitter)</span> <svg
+    class="h-6 w-6"
+    fill="currentColor"
+    viewBox="0 0 512 512"
+    aria-hidden="true"
+  >
+    <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/>
+  </svg>
+</a>
             <a
               href="#"
               class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"

--- a/index.html
+++ b/index.html
@@ -876,21 +876,18 @@
               </svg>
             </a>
             <a
-              href="#"
-              class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"
-            >
-              <span class="sr-only">Twitter</span>
-              <svg
-                class="h-6 w-6"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84"
-                ></path>
-              </svg>
-            </a>
+  href="#"
+  class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"
+>
+  <span class="sr-only">X (Twitter)</span> <svg
+    class="h-6 w-6"
+    fill="currentColor"
+    viewBox="0 0 512 512"
+    aria-hidden="true"
+  >
+    <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/>
+  </svg>
+</a>
             <a
               href="#"
               class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"

--- a/player.html
+++ b/player.html
@@ -954,12 +954,19 @@
                                 <path fill-rule="evenodd" d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z" clip-rule="evenodd"></path>
                             </svg>
                         </a>
-                        <a href="#" class="text-neutral-300 hover:text-white transition-colors">
-                            <span class="sr-only">Twitter</span>
-                            <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                                <path d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84"></path>
-                            </svg>
-                        </a>
+                        <a
+  href="#"
+  class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"
+>
+  <span class="sr-only">X (Twitter)</span> <svg
+    class="h-6 w-6"
+    fill="currentColor"
+    viewBox="0 0 512 512"
+    aria-hidden="true"
+  >
+    <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/>
+  </svg>
+</a>
                         <a href="#" class="text-neutral-300 hover:text-white transition-colors">
                             <span class="sr-only">LinkedIn</span>
                             <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">

--- a/privacy.html
+++ b/privacy.html
@@ -255,12 +255,19 @@
                             <path fill-rule="evenodd" d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z" clip-rule="evenodd"></path>
                         </svg>
                     </a>
-                    <a href="#" class="text-neutral-300 hover:text-white transition-colors">
-                        <span class="sr-only">Twitter</span>
-                        <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84"></path>
-                        </svg>
-                    </a>
+                    <a
+  href="#"
+  class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"
+>
+  <span class="sr-only">X (Twitter)</span> <svg
+    class="h-6 w-6"
+    fill="currentColor"
+    viewBox="0 0 512 512"
+    aria-hidden="true"
+  >
+    <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/>
+  </svg>
+</a>
                     <a href="#" class="text-neutral-300 hover:text-white transition-colors">
                         <span class="sr-only">LinkedIn</span>
                         <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">

--- a/student-courses.html
+++ b/student-courses.html
@@ -125,12 +125,19 @@
                             <path fill-rule="evenodd" d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z" clip-rule="evenodd"></path>
                         </svg>
                     </a>
-                    <a href="#" class="text-neutral-300 hover:text-white transition-colors">
-                        <span class="sr-only">Twitter</span>
-                        <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84"></path>
-                        </svg>
-                    </a>
+                    <a
+  href="#"
+  class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"
+>
+  <span class="sr-only">X (Twitter)</span> <svg
+    class="h-6 w-6"
+    fill="currentColor"
+    viewBox="0 0 512 512"
+    aria-hidden="true"
+  >
+    <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/>
+  </svg>
+</a>
                     <a href="#" class="text-neutral-300 hover:text-white transition-colors">
                         <span class="sr-only">LinkedIn</span>
                         <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">

--- a/terms.html
+++ b/terms.html
@@ -215,12 +215,19 @@
                             <path fill-rule="evenodd" d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z" clip-rule="evenodd"></path>
                         </svg>
                     </a>
-                    <a href="#" class="text-neutral-300 hover:text-white transition-colors">
-                        <span class="sr-only">Twitter</span>
-                        <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84"></path>
-                        </svg>
-                    </a>
+                    <a
+  href="#"
+  class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"
+>
+  <span class="sr-only">X (Twitter)</span> <svg
+    class="h-6 w-6"
+    fill="currentColor"
+    viewBox="0 0 512 512"
+    aria-hidden="true"
+  >
+    <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/>
+  </svg>
+</a>
                     <a href="#" class="text-neutral-300 hover:text-white transition-colors">
                         <span class="sr-only">LinkedIn</span>
                         <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">

--- a/verification.html
+++ b/verification.html
@@ -260,12 +260,19 @@
                             <path fill-rule="evenodd" d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z" clip-rule="evenodd"></path>
                         </svg>
                     </a>
-                    <a href="#" class="text-neutral-300 hover:text-white transition-colors">
-                        <span class="sr-only">Twitter</span>
-                        <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84"></path>
-                        </svg>
-                    </a>
+                    <a
+  href="#"
+  class="text-neutral-300 hover:text-white transition-colors duration-200 transform hover:scale-110"
+>
+  <span class="sr-only">X (Twitter)</span> <svg
+    class="h-6 w-6"
+    fill="currentColor"
+    viewBox="0 0 512 512"
+    aria-hidden="true"
+  >
+    <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/>
+  </svg>
+</a>
                     <a href="#" class="text-neutral-300 hover:text-white transition-colors">
                         <span class="sr-only">LinkedIn</span>
                         <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #126 
## Rationale for this change

The website was displaying the legacy Twitter "bird" icon in the footer and contact sections across multiple pages. To maintain accurate and modern branding, this needed to be updated to the official **X** logo.

## What changes are included in this PR?

- **Global Icon Update:** Replaced the outdated `fa-twitter` / `<i>` tags with the official **X Logo SVG** in all HTML files (including `index.html`, `about.html`, `courses.html`, `contact.html`, etc.).
- **Consistent Styling:** Preserved existing classes (e.g., `hover:scale-110`, `text-neutral-300`) to ensure the new SVG matches the style and behavior of other social icons.
- **Accessibility:** Updated screen reader text from "Twitter" to "X (Twitter)" where applicable.

## Are these changes tested?

Yes. I tested the changes locally:
- Verified that the new X SVG renders correctly on all pages.
- Confirmed that hover animations and colors still work as expected.
- Checked alignment with adjacent icons (Facebook, Instagram, LinkedIn).

## Are there any user-facing changes?

Yes. The social media links in the footer and contact sections now display the modern **X** logo instead of the old Twitter bird.

<img width="952" height="122" alt="image" src="https://github.com/user-attachments/assets/528b0eca-79c0-4cf3-8af5-2e5bd5cbd50e" />